### PR TITLE
Add devShell to Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,22 @@
 
       };
 
+      devShells.default = nixpkgs.mkShell {
+        packages = with nixpkgs; [
+          alsaLib
+          libbsd
+          libevent
+          libjpeg
+          libopus
+          glib
+          jansson
+          janus-gateway
+          pkg-config
+          python39
+          speex
+        ];
+      };
+
       packages = forAllSystems (system:
         {
           inherit (nixpkgsFor.${system}) ustreamer;


### PR DESCRIPTION
It doesn't build on this version of the repo, but it builds on the latest ustreamer master commit (a4b4dd3932e54e55c98d62d0c35d93818e10982d). If you sync your fork with the latest changes from pikvm/ustreamer, the dev shell should work partially.

I haven't been able to get `make all WITH_PYTHON=1` or `make all WITH_JANUS=1` to work fully. The Janus problem is due to the weirdness in Janus' headers: https://github.com/pikvm/ustreamer/blob/master/docs/h264.md#fixing-janus-c-headers